### PR TITLE
Include stylesheets starting with "blob:"

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -309,6 +309,7 @@ export const cqfill = ((
 							&& (
 								!styleSheet.href
 								|| styleSheet.href.startsWith(location.origin)
+								|| styleSheet.href.startsWith(`blob:${location.origin}`)
 							)
 						) {
 							polyfillContainerQueries(root, styleSheet)


### PR DESCRIPTION
Frontend frameworks like Gatsby use these URLs in development. What do you think?