### PR TITLE
Remove unused variable

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -53,7 +53,7 @@ export const cqfill = ((
 	insertCssRule = (cssParentRule, cssText, index) => cssParentRule.cssRules[cssParentRule.insertRule(cssText, index)],
 
 	onResize = () => {
-		for (const [containedSelectorText, innerRule, doesFulfillQuery, axis] of containerQueries) {
+		for (const [containedSelectorText, innerRule, doesFulfillQuery, ] of containerQueries) {
 			/** @type {Set<Element>} */
 			const fulfilledElements = new Set()
 


### PR DESCRIPTION
Fixes #11 in theory by removing the unused variable that terser was shadowing.

Using https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#ignoring_some_returned_values