### PR TITLE
Added support for multiple containers

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -126,7 +126,7 @@ export const cqfill = ((
 			const doesMatchAllElements = elements.length === lastElements.length && every.call(elements, doesMatchElement)
 
 			if (!doesMatchAllElements) {
-				layoutContainerSet.clear()
+				// layoutContainerSet.clear()
 
 				ro.disconnect()
 


### PR DESCRIPTION
From what i have noticed the layoutContainerSet variable is being cleared on each mutation and therefore it has only one container element, I just removed the clear command so it will add all the containers to the set, It seems to function properly with multiple containers on the same page now.

What do you think ?